### PR TITLE
Enable running without dftd3 and fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ print(mf.pol_tot.trace() / 3)  # 4.9747082620200915 in a.u.
 Hessian is currently not implemented.
 
 ## Install
+### Pre-requistes
+* python >= 3.7
 
 ### `dh` as PySCF extension
 Refer to installation of PySCF [Extension modules](https://pyscf.org/install.html#extension-modules).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ to much smaller value for `dh` extension.
 If you are not using functionals with "-D3" suffix, you can safely omit this part.
 
 To calculate functionals that includes D3 dispersion correction, user may need to install
-[pyscf/dftd3]() as an extension of PySCF. 
+[pyscf/dftd3](https://github.com/pyscf/dftd3) as an extension of PySCF. 
 
 Furthermore, this extension requires a dynamic library `libdftd3.so`, which should be compiled by user.
 - Source code of the library could be accessed from [ajz34/libdftd3](https://github.com/ajz34/libdftd3);

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ print(mf.pol_tot.trace() / 3)  # 4.9747082620200915 in a.u.
 Hessian is currently not implemented.
 
 ## Install
-### Pre-requistes
+### Pre-requisites
 * python >= 3.7
 
 ### `dh` as PySCF extension

--- a/examples/00-dh-energy.py
+++ b/examples/00-dh-energy.py
@@ -1,8 +1,8 @@
 # for development, import dh
 # for general user, import pyscf.dh
 
-from pyscf import gto, dft, mp
-from dh import DFDH
+from pyscf import gto, dft, mp, dh
+#from dh import DFDH
 
 
 def get_energy_xDH(mol: gto.Mole, xc_scf: str, c_pt2: float, xc_dh: str or None=None):
@@ -25,19 +25,19 @@ if __name__ == '__main__':
     #          PySCF   -76.2910535257
     #          RDFDH   -76.2910470614
     print(get_energy_xDH(mol, "B3LYPg", 0.3211, "0.8033*HF - 0.0140*LDA + 0.2107*B88, 0.6789*LYP"))
-    print(DFDH(mol, xc="XYG3").run().e_tot)
+    print(dh.DFDH(mol, xc="XYG3").run().e_tot)
     # B2PLYP   QChem   -76.29075997
     #          PySCF   -76.29075969
     #          RDFDH   -76.29076324
     print(get_energy_xDH(mol, "0.53*HF + 0.47*B88, 0.73*LYP", 0.27))
-    print(DFDH(mol, xc="B2PLYP").run().e_tot)
+    print(dh.DFDH(mol, xc="B2PLYP").run().e_tot)
     # XYGJ-OS  QChem   -76.1460262831
     #          RDFDH   -76.1460317123
-    print(DFDH(mol, xc="XYGJ-OS").run().e_tot)
+    print(dh.DFDH(mol, xc="XYGJ-OS").run().e_tot)
     # MP2      PySCF   -76.1108060780191
     #          RDFDH   -76.1107838767765
     print(mp.MP2(mol).run().e_tot)
-    print(DFDH(mol, xc="MP2").run().e_tot)
+    print(dh.DFDH(mol, xc="MP2").run().e_tot)
     # Details:  QChem uses 99, 590 grid; i.e. XC_GRID 000099000590
     #                 no density fitting used in QChem for XYG3, B2PLYP, MP2
     #                 LT-SOS-RI-MP2 for XYGJ-OS

--- a/examples/01-dh-grad.py
+++ b/examples/01-dh-grad.py
@@ -1,8 +1,8 @@
 # for development, import dh
 # for general user, import pyscf.dh
 
-from pyscf import gto
-from dh import DFDH
+from pyscf import gto, dh
+#from dh import DFDH
 import numpy as np
 
 np.set_printoptions(5, suppress=True, linewidth=180)
@@ -14,8 +14,8 @@ if __name__ == '__main__':
     #  [-0.16752  0.02649  0.02154]
     #  [ 0.02384 -0.03202  0.01631]
     #  [ 0.01762  0.01483  0.04038]]
-    print(DFDH(mol, xc="XYG3").run().e_tot)
-    mf = DFDH(mol, xc="XYG3").nuc_grad_method().run()
+    print(dh.DFDH(mol, xc="XYG3").run().e_tot)
+    mf = dh.DFDH(mol, xc="XYG3").nuc_grad_method().run()
     print(mf.e_tot)
     print(mf.de)
     # B2PLYP
@@ -23,8 +23,8 @@ if __name__ == '__main__':
     #  [-0.17088  0.02598  0.0211 ]
     #  [ 0.02338 -0.03631  0.01602]
     #  [ 0.01726  0.01457  0.03565]]
-    print(DFDH(mol, xc="B2PLYP").run().e_tot)
-    mf = DFDH(mol, xc="B2PLYP").nuc_grad_method().run()
+    print(dh.DFDH(mol, xc="B2PLYP").run().e_tot)
+    mf = dh.DFDH(mol, xc="B2PLYP").nuc_grad_method().run()
     print(mf.e_tot)
     print(mf.de)
     # MP2
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     #  [-0.17439  0.02557  0.02063]
     #  [ 0.02301 -0.03636  0.01541]
     #  [ 0.01688  0.01401  0.03824]]
-    print(DFDH(mol, xc="MP2").run().e_tot)
-    mf = DFDH(mol, xc="MP2").nuc_grad_method().run()
+    print(dh.DFDH(mol, xc="MP2").run().e_tot)
+    mf = dh.DFDH(mol, xc="MP2").nuc_grad_method().run()
     print(mf.e_tot)
     print(mf.de)

--- a/examples/02-dh-polar.py
+++ b/examples/02-dh-polar.py
@@ -1,8 +1,8 @@
 # for development, import dh
 # for general user, import pyscf.dh
 
-from pyscf import gto
-from dh import DFDH
+from pyscf import gto, dh
+#from dh import DFDH
 import numpy as np
 
 np.set_printoptions(5, suppress=True, linewidth=180)
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     # [[ 7.26795 -0.15045 -0.21885]
     #  [-0.15045  8.75195 -0.367  ]
     #  [-0.21885 -0.367   10.47337]]
-    mf = DFDH(mol, xc="XYG3").polar_method().run()
+    mf = dh.DFDH(mol, xc="XYG3").polar_method().run()
     print(mf.dipole())
     print(mf.pol_tot)
     # B2PLYP
@@ -23,7 +23,7 @@ if __name__ == '__main__':
     # [[ 7.38219 -0.15075 -0.21973]
     #  [-0.15075  8.86653 -0.36795]
     #  [-0.21973 -0.36795 10.5606 ]]
-    mf = DFDH(mol, xc="B2PLYP").polar_method().run()
+    mf = dh.DFDH(mol, xc="B2PLYP").polar_method().run()
     print(mf.dipole())
     print(mf.pol_tot)
     # MP2
@@ -31,6 +31,6 @@ if __name__ == '__main__':
     # [[ 7.28733 -0.14367 -0.2035 ]
     #  [-0.14367  8.72405 -0.33421]
     #  [-0.2035  -0.33421 10.34546]]
-    mf = DFDH(mol, xc="MP2").polar_method().run()
+    mf = dh.DFDH(mol, xc="MP2").polar_method().run()
     print(mf.dipole())
     print(mf.pol_tot)

--- a/examples/03-udh-grad.py
+++ b/examples/03-udh-grad.py
@@ -1,5 +1,5 @@
-from pyscf import gto
-from dh import DFDH
+from pyscf import gto, dh
+#from dh import DFDH
 import numpy as np
 
 np.set_printoptions(5, suppress=True, linewidth=180)
@@ -11,8 +11,8 @@ if __name__ == '__main__':
     #  [-0.25042  0.04956  0.04518]
     #  [ 0.04461 -0.09688  0.03794]
     #  [ 0.03696  0.03449 -0.00912]]
-    print(DFDH(mol, xc="XYG3").run().e_tot)
-    mf = DFDH(mol, xc="XYG3").nuc_grad_method().run()
+    print(dh.DFDH(mol, xc="XYG3").run().e_tot)
+    mf = dh.DFDH(mol, xc="XYG3").nuc_grad_method().run()
     print(mf.e_tot)
     print(mf.de)
     # B2PLYP
@@ -20,8 +20,8 @@ if __name__ == '__main__':
     #  [-0.25191  0.04861  0.04429]
     #  [ 0.04375 -0.09947  0.03721]
     #  [ 0.03624  0.03383 -0.01239]]
-    print(DFDH(mol, xc="B2PLYP").run().e_tot)
-    mf = DFDH(mol, xc="B2PLYP").nuc_grad_method().run()
+    print(dh.DFDH(mol, xc="B2PLYP").run().e_tot)
+    mf = dh.DFDH(mol, xc="B2PLYP").nuc_grad_method().run()
     print(mf.e_tot)
     print(mf.de)
     # MP2
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     #  [-0.25667  0.04885  0.04455]
     #  [ 0.04397 -0.10097  0.03734]
     #  [ 0.03645  0.03395 -0.01123]]
-    print(DFDH(mol, xc="MP2").run().e_tot)
-    mf = DFDH(mol, xc="MP2").nuc_grad_method().run()
+    print(dh.DFDH(mol, xc="MP2").run().e_tot)
+    mf = dh.DFDH(mol, xc="MP2").nuc_grad_method().run()
     print(mf.e_tot)
     print(mf.de)

--- a/examples/04-opt.py
+++ b/examples/04-opt.py
@@ -1,8 +1,8 @@
 # for development, import dh
 # for general user, import pyscf.dh
 
-from pyscf import gto, lib
-from dh import DFDH
+from pyscf import gto, lib, dh
+#from dh import DFDH
 from pyscf.geomopt.geometric_solver import optimize
 import numpy as np
 
@@ -13,10 +13,10 @@ if __name__ == '__main__':
 
     # Restricted Case
     mol = gto.Mole(atom="O; H 1 1.0; H 1 1.0 2 104.5", basis="6-31G", verbose=0).build()
-    mf = DFDH(mol, xc="XYG3").nuc_grad_method()
+    mf = dh.DFDH(mol, xc="XYG3").nuc_grad_method()
     mol_eq = optimize(mf)
     print(mol_eq.atom_coords() * lib.param.BOHR)  # print optimized geom in Angstrom
-    print(DFDH(mol_eq, xc="XYG3").nuc_grad_method().run().de)  # should be allclose to zero
+    print(dh.DFDH(mol_eq, xc="XYG3").nuc_grad_method().run().de)  # should be allclose to zero
     # [[ 0.023265 -0.        0.030072]
     #  [ 0.988122 -0.       -0.014877]
     #  [-0.261803 -0.        0.952951]]
@@ -24,10 +24,10 @@ if __name__ == '__main__':
 
     # Unrestricted Case
     mol = gto.Mole(atom="O; O 1 1.2", basis="6-31G", spin=2, verbose=0).build()
-    mf = DFDH(mol, xc="XYG3").nuc_grad_method()
+    mf = dh.DFDH(mol, xc="XYG3").nuc_grad_method()
     mol_eq = optimize(mf)
     print(mol_eq.atom_coords() * lib.param.BOHR)  # print optimized geom in Angstrom
-    print(DFDH(mol_eq, xc="XYG3").nuc_grad_method().run().de)  # should be allclose to zero
+    print(dh.DFDH(mol_eq, xc="XYG3").nuc_grad_method().run().de)  # should be allclose to zero
     # [[-0.056206 -0.       -0.      ]
     #  [ 1.256206  0.        0.      ]]
     # converge in 5 steps

--- a/examples/10-kdh.py
+++ b/examples/10-kdh.py
@@ -9,7 +9,7 @@ import numpy
 from pyscf.pbc import gto
 from pyscf import pbcdh, lib
 
-lib.num_threads(28)
+#lib.num_threads(28)
 
 cell = gto.Cell()
 cell.atom='''

--- a/pyscf/dh/grad/rdfdh.py
+++ b/pyscf/dh/grad/rdfdh.py
@@ -10,7 +10,12 @@ except ImportError:
 from pyscf import gto, lib, df
 from pyscf.dft.numint import _dot_ao_dm, _contract_rho
 from pyscf.df.grad.rhf import _int3c_wrapper as int3c_wrapper
-from pyscf.dftd3 import itrf
+try:
+    from pyscf.dftd3 import itrf
+except ImportError:
+    print('''Warning: dftd3 not found. You cannot using functionals with "-D3" suffix 
+             before installing pyscf-dftd3. See https://github.com/pyscf/dftd3 and
+             https://github.com/ajz34/dh#dftd3-extension ''') 
 # other import
 import numpy as np
 import ctypes

--- a/pyscf/dh/grad/udfdh.py
+++ b/pyscf/dh/grad/udfdh.py
@@ -13,7 +13,12 @@ except ImportError:
 # pyscf import
 from pyscf import gto, lib, df
 from pyscf.df.grad.rhf import _int3c_wrapper as int3c_wrapper
-from pyscf.dftd3 import itrf
+try:
+    from pyscf.dftd3 import itrf
+except ImportError:
+    print('''Warning: dftd3 not found. You cannot using functionals with "-D3" suffix 
+             before installing pyscf-dftd3. See https://github.com/pyscf/dftd3 and
+             https://github.com/ajz34/dh#dftd3-extension ''') 
 # other import
 import numpy as np
 import itertools

--- a/pyscf/dh/rdfdh.py
+++ b/pyscf/dh/rdfdh.py
@@ -14,7 +14,12 @@ from pyscf.scf import cphf
 from pyscf import lib, gto, df, dft, scf
 from pyscf.ao2mo import _ao2mo
 from pyscf.scf._response_functions import _gen_rhf_response
-from pyscf.dftd3 import itrf
+try:
+    from pyscf.dftd3 import itrf
+except ImportError:
+    print('''Warning: dftd3 not found. You cannot using functionals with "-D3" suffix 
+             before installing pyscf-dftd3. See https://github.com/pyscf/dftd3 and
+             https://github.com/ajz34/dh#dftd3-extension ''') 
 # other import
 import os
 import pickle


### PR DESCRIPTION
* add `try` before importing dftd3 to ensure running XYG3 without dftd3 is ok
* fix link to dftd3
* fix import error in examples
* add pre-requisite python>=3.7, since annotations don't work in 3.6